### PR TITLE
Fixed HQX_MIX_2 and HQX_MIX_3 warnings in g++

### DIFF
--- a/include/hqx/HQx.hh
+++ b/include/hqx/HQx.hh
@@ -32,7 +32,7 @@
 #define HQX_MIX_2(C0,C1,W0,W1) \
 	((((C0 & MASK_RB) * W0 + (C1 & MASK_RB) * W1) / (W0 + W1)) & MASK_RB) | \
 	((((C0 & MASK_G)  * W0 + (C1 & MASK_G)  * W1) / (W0 + W1)) & MASK_G)  | \
-	(((((C0 & MASK_A) >> 8)  * W0 + ((C1 & MASK_A) >> 8) * W1) / (W0 + W1)) << 8) & MASK_A
+	((((((C0 & MASK_A) >> 8)  * W0 + ((C1 & MASK_A) >> 8) * W1) / (W0 + W1)) << 8) & MASK_A)
 
 /**
  * @brief Mixes three colors using the given weights.
@@ -40,7 +40,7 @@
 #define HQX_MIX_3(C0,C1,C2,W0,W1,W2) \
 	((((C0 & MASK_RB) * W0 + (C1 & MASK_RB) * W1 + (C2 & MASK_RB) * W2) / (W0 + W1 + W2)) & MASK_RB) | \
 	((((C0 & MASK_G)  * W0 + (C1 & MASK_G)  * W1 + (C2 & MASK_G)  * W2) / (W0 + W1 + W2)) & MASK_G)  | \
-	(((((C0 & MASK_A) >> 8) * W0 + ((C1 & MASK_A) >> 8) * W1 + ((C2 & MASK_A) >> 8) * W2) / (W0 + W1 + W2)) << 8) & MASK_A
+	((((((C0 & MASK_A) >> 8) * W0 + ((C1 & MASK_A) >> 8) * W1 + ((C2 & MASK_A) >> 8) * W2) / (W0 + W1 + W2)) << 8) & MASK_A)
 
 
 #define MIX_00_4				*output = w[4];


### PR DESCRIPTION
Missing parentheses cause huge warning output, around 6000 lines in [godot](https://github.com/godotengine/godot/issues/5509), in g++ with `-Wall`, this fixes said warnings. 
